### PR TITLE
feat: Store All data

### DIFF
--- a/includes/class-export-parser.php
+++ b/includes/class-export-parser.php
@@ -43,6 +43,19 @@ class Export_Parser {
 			}
 		}
 
+		// Reorder the export_line to match the CSV fields order.
+		$csv_fields_order = Settings::get_setting( Settings::CSV_FIELDS );
+
+		if ( ! empty( $csv_fields_order ) ) {
+			$ordered_line = array_fill_keys( $csv_fields_order, '' );
+			foreach ( $export_line as $key => $value ) {
+				if ( in_array( $key, $csv_fields_order ) ) {
+					$ordered_line[ $key ] = $value;
+				}
+			}
+			$export_line = $ordered_line;
+		}
+
 		return $export_line;
 	}
 }

--- a/includes/class-import-parser.php
+++ b/includes/class-import-parser.php
@@ -39,8 +39,12 @@ class Import_Parser {
 		foreach ( $newspack_fields as $key => $field ) {
 			if ( isset( $mapping[ $key ] ) && isset( $line[ $mapping[ $key ] ] ) ) {
 				$parsed_line[ $key ] = $line[ $mapping[ $key ] ];
-			} else {
-				$parsed_line[ $key ] = '';
+			}
+		}
+
+		foreach ( $mapping as $key => $index ) {
+			if ( ! isset( $parsed_line[ $key ] ) && isset( $line[ $index ] ) ) {
+				$parsed_line[ $key ] = $line[ $index ];
 			}
 		}
 

--- a/includes/class-import.php
+++ b/includes/class-import.php
@@ -248,6 +248,11 @@ class Import {
 		// Get the header.
 		$header = fgetcsv( $csv_file );
 
+		// If csv export fields are not set set them to the header.
+		if ( 0 === $offset && empty( Settings::get_setting( Settings::CSV_FIELDS ) ) ) {
+			Settings::set_setting( Settings::CSV_FIELDS, $header );
+		}
+
 		// Skip rows until the offset is reached.
 		$line = 0;
 		while ( $line < $offset && ( $row = fgetcsv( $csv_file ) ) !== false ) {

--- a/includes/class-newspack-fields.php
+++ b/includes/class-newspack-fields.php
@@ -26,7 +26,7 @@ class Newspack_Fields {
 	const ZIP_FIELD            = 'zip';
 	const PHONE_FIELD          = 'phone';
 	const STATUS               = 'status';
-	// const EXTRA_FIELD          = 'newspack_circ_extra';
+	const EXTRA_FIELD          = 'newspack_circ_extra';
 
 	/**
 	 * Get the fields to be mapped.
@@ -90,6 +90,11 @@ class Newspack_Fields {
 				'type'     => 'user_meta',
 				'db_field' => 'newspack_print_circ_status',
 			],
+			self::EXTRA_FIELD          => [
+				'label'    => 'Extra Data',
+				'type'     => 'extra_data',
+				'db_field' => 'newspack_circ_extra_data',
+			],
 		];
 	}
 
@@ -123,8 +128,21 @@ class Newspack_Fields {
 		$fields = self::get_fields();
 		$user_array = [];
 		foreach ( $fields as $slug => $field ) {
+			if( self::EXTRA_FIELD === $slug ) {
+				// Skip the extra field as it is handled separately.
+				continue;
+			}
 			$user_array[ $slug ] = self::get_field_value( $slug, $user_id );
 		}
+
+		// Get the extra data field.
+		$extra_field = self::get_field( self::EXTRA_FIELD );
+		$extra_data  = get_user_meta( $user_id, $extra_field['db_field'], true );
+		if ( is_array( $extra_data ) ) {
+			// Merge extra data into the user array.
+			$user_array = array_merge( $user_array, $extra_data );
+		}
+
 		return $user_array;
 	}
 
@@ -150,6 +168,31 @@ class Newspack_Fields {
 			// If its a user property.
 			$user = get_user_by( 'id', $user_id );
 			return $user->{$field['db_field']};
+		} else {
+			// Handle nested extra data
+			$extra_field = self::get_field( self::EXTRA_FIELD );
+			$extra_data  = get_user_meta( $user_id, $extra_field['db_field'], true );
+			
+			if ( ! is_array( $extra_data ) ) {
+				return null;
+			}
+
+			// Check if slug contains nested path (e.g., 'parent.child.key')
+			if ( strpos( $slug, '.' ) !== false ) {
+				$keys  = explode( '.', $slug );
+				$value = $extra_data;
+				
+				foreach ( $keys as $key ) {
+					if ( ! is_array( $value ) || ! isset( $value[ $key ] ) ) {
+						return null;
+					}
+					$value = $value[ $key ];
+				}
+				
+				return $value;
+			}
+			
+			return $extra_data[ $slug ] ?? null;
 		}
 	}
 
@@ -176,6 +219,35 @@ class Newspack_Fields {
 			$user = get_user_by( 'id', $user_id );
 			$user->{$field['db_field']} = $value;
 			wp_update_user( $user );
+		} else {
+			$extra_field = self::get_field( self::EXTRA_FIELD );
+			// Store as a part of the user's extra data.
+			$extra_data = get_user_meta( $user_id, $extra_field['db_field'], true );
+			if ( ! is_array( $extra_data ) ) {
+				$extra_data = [];
+			}
+
+			// Handle nested data
+			if ( strpos( $slug, '.' ) !== false ) {
+				$keys   = explode( '.', $slug );
+				$target = &$extra_data;
+				
+				// Navigate to the nested location
+				foreach ( $keys as $index => $key ) {
+					if ( $index === count( $keys ) - 1 ) {
+						$target[ $key ] = $value;
+					} else {
+						if ( ! isset( $target[ $key ] ) || ! is_array( $target[ $key ] ) ) {
+							$target[ $key ] = [];
+						}
+						$target = &$target[ $key ];
+					}
+				}
+			} else {
+				$extra_data[ $slug ] = $value;
+			}
+
+			update_user_meta( $user_id, $extra_field['db_field'], $extra_data );
 		}
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -30,6 +30,11 @@ class Settings {
 	const CSV_MAPPING_OPTION = 'csv_mapping';
 
 	/**
+	 * CSV Fields to be exported.
+	 */
+	const CSV_FIELDS = 'csv_fields';
+
+	/**
 	 * Default role to be granted to the imported users.
 	 */
 	const DEFAULT_ROLES_OPTION = 'default_roles';
@@ -519,5 +524,20 @@ class Settings {
 		}
 
 		return $options[ $option ];
+	}
+
+	/**
+	 * Explicitly set a setting value.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Option value.
+	 */
+	public static function set_setting( $option, $value ) {
+		$options = get_option( self::SETTINGS_OPTION );
+		if ( ! is_array( $options ) ) {
+			$options = [];
+		}
+		$options[ $option ] = $value;
+		update_option( self::SETTINGS_OPTION, $options );
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -68,17 +68,19 @@ class Settings {
 	 * @var array
 	 */
 	public static $default_mapping = [
-		'circ_id'      => 'Account',
-		'status'       => 'Status',
-		'first_name'   => 'First Name',
-		'last_name'    => 'Last Name',
-		'display_name' => 'Display Name',
-		'email'        => 'Email',
-		'phone'        => 'Phone- Last 4',
-		'address'      => 'Address',
-		'city'         => 'City',
-		'state'        => 'State',
-		'zip'          => 'Zip',
+		'publication_name'        => 'Publication Name',
+		'status'                  => 'Status',
+		'circ_id'                 => 'Account',
+		'first_name'              => 'First Name',
+		'last_name'               => 'Last Name',
+		'display_name'            => 'Display Name',
+		'email'                   => 'Email',
+		'phone'                   => 'Phone- Last 4',
+		'address'                 => 'Address',
+		'city'                    => 'City',
+		'state'                   => 'State',
+		'zip'                     => 'Zip',
+		"subscription_expiration" => "Expiration",
 	];
 
 	/**

--- a/includes/wp-cli/class-import.php
+++ b/includes/wp-cli/class-import.php
@@ -62,8 +62,8 @@ class Import {
 		$total_processed = 0;
 
 		if ( $is_dry_run ) {
-			$fields = array_keys( Newspack_Fields::get_fields() );
 			$result = $import_module->test_import_users();
+			$fields = array_keys( $result[0] );
 			WP_CLI\Utils\format_items(
 				'table',
 				$result,


### PR DESCRIPTION
To Address:
> [The exported CSV file must match the CSV we use as testing.](https://github.com/Automattic/newspack-print-circ-integration/pull/3#:~:text=The%20exported%20CSV%20file%20must%20match%20the%20CSV%20we%20use%20as%20testing.)

Basically, to achieve this we will need to store all the data that the CSV import provides. This means we must also store all the extra fields apart from the standard Newspack Print Circ fields that are essential. Previously I had implemented code to do this via an "extra field" in user meta to store the "extra data", however it was shelved. I am reimplementing the same to achieve this.

- Store the standard fields in their respective fields, store all extras in the extra field.
- Store the order of the fields in the import CSV.
- Sort the user data to match the import csv order before exporting.