### PR TITLE
Fix critical npm dependency alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3777,22 +3777,6 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
-		"node_modules/@playwright/test": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
-			"integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright": "1.51.0"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
 			"version": "0.5.15",
 			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
@@ -12242,10 +12226,11 @@
 			]
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+			"integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -16284,14 +16269,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -16971,10 +16958,11 @@
 			"dev": true
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5",
 				"neo-async": "^2.6.2",
@@ -24684,53 +24672,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/playwright": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
-			"integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright-core": "1.51.0"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/playwright-core": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
-			"integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
 	},
 	"dependencies": {
 		"clean": "^4.0.2"
+	},
+	"overrides": {
+		"basic-ftp": "5.2.1",
+		"form-data": "4.0.4",
+		"handlebars": "4.7.9"
 	}
 }


### PR DESCRIPTION
## Summary
- add npm overrides for patched `handlebars`, `basic-ftp`, and `form-data`
- refresh `package-lock.json` under the repo's Node 22.12.0 runtime
- enable Dependabot security updates for the repo

## Validation
- `nvm install 22.12.0`
- `npm install --package-lock-only --ignore-scripts --legacy-peer-deps`
- `npm ci --ignore-scripts --legacy-peer-deps`
- `npm audit --audit-level=critical --json` reports 0 critical vulnerabilities
- `npm ls handlebars basic-ftp form-data --all`
- `composer validate --no-check-publish`
- `composer install --no-interaction --no-progress`
- PHP syntax check across tracked PHP files
- `npm test` reports no tests found
- `git diff --check`

Known existing validation gaps:
- `npm run build` fails because the repo does not have `webpack.config.js`
- `npm run lint:js` fails because `@typescript-eslint/eslint-plugin` is missing from the installed package graph referenced by `newspack-scripts`
- `./vendor/bin/phpcs` reports pre-existing PHPCS issues in `includes/`
